### PR TITLE
issue #2078 add WriteNonStringKeyAsString to defaultFeature

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -101,6 +101,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
         features |= SerializerFeature.SkipTransientField.getMask();
         features |= SerializerFeature.WriteEnumUsingName.getMask();
         features |= SerializerFeature.SortField.getMask();
+        features |= SerializerFeature.WriteNonStringKeyAsString.getMask();
 
         {
             String featuresProperty = IOUtils.getStringProperty("fastjson.serializerFeatures.MapSortField");


### PR DESCRIPTION
even user not specify WriteNonStringKeyAsString feature when using toJSONString(), all keys in JSON need to be String